### PR TITLE
Tweak: Use the selection for proposed substitution 

### DIFF
--- a/BBEdit Additions/Clippings/CM Substitute
+++ b/BBEdit Additions/Clippings/CM Substitute
@@ -1,1 +1,1 @@
-{~~ #selection# ~> #PLACEHOLDERSTART#substitution#PLACEHOLDEREND# ~~}
+{~~ #selection# ~> #SELSTART##SELECT##SELEND# ~~}


### PR DESCRIPTION
This commit changes the behavior of the substitution mark clipping by using the selection as the proposed substitution text and then selecting it.

This will allow users to do quick and common transformations on the selection (e.g. change case, smarten/dumben quotes, apply a text filter) without having to retype the word/phrase under revision. 
