### PR TITLE
Use /usr/bin/env in shebang for portability

### DIFF
--- a/CLI/criticParser_CLI.py
+++ b/CLI/criticParser_CLI.py
@@ -1,4 +1,4 @@
-#!/opt/local/bin/python
+#!/usr/bin/env python
 
 import codecs
 import sys


### PR DESCRIPTION
Shebang will now handle different installations of python more gracefully. See: https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability for more details.

Fixes CriticMarkup/CriticMarkup-toolkit#16
