### PR TITLE
Fixes Sublime Text 3 Highlight syntax

### DIFF
--- a/Sublime Text 3 Package/Critic Markup/Critic.tmLanguage
+++ b/Sublime Text 3 Package/Critic Markup/Critic.tmLanguage
@@ -38,7 +38,7 @@
 			<key>highlight</key>
 			<string>Editorial Highlight</string>
 			<key>match</key>
-			<string>\{\{(.*?)[ \t]*(\[(.*?)\])?[ \t]*\}\}</string>
+			<string>\{==(.*?)[ \t]*(\[(.*?)\])?[ \t]*==\}</string>
 			<key>name</key>
 			<string>string.highlight</string>
 		</dict>

--- a/Sublime Text 3 Package/Critic Markup/Markdown + Critic.tmLanguage
+++ b/Sublime Text 3 Package/Critic Markup/Markdown + Critic.tmLanguage
@@ -547,7 +547,7 @@
 					<key>highlight</key>
 					<string>Editorial Highlight</string>
 					<key>match</key>
-					<string>\{\{(.*?)[ \t]*(\[(.*?)\])?[ \t]*\}\}</string>
+					<string>\{==(.*?)[ \t]*(\[(.*?)\])?[ \t]*==\}</string>
 					<key>name</key>
 					<string>string.highlight</string>
 				</dict>

--- a/Sublime Text 3 Package/Critic Markup/list_critics_comments.py
+++ b/Sublime Text 3 Package/Critic Markup/list_critics_comments.py
@@ -4,7 +4,7 @@ import re
 class ListCriticsCommentsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         self.markers = []
-        self.view.find_all(r'''(?s)((\{>>(.*?)<<\})|(\{\{(.*?)\}\}\{>>(.*?)<<\}))''', 0, "$1", self.markers)
+        self.view.find_all(r'''(?s)((\{>>(.*?)<<\})|(\{==(.*?)==\}\{>>(.*?)<<\}))''', 0, "$1", self.markers)
         self.view.window().show_quick_panel(self.markers, self.goto_critic, sublime.MONOSPACE_FONT)
 
     def goto_critic(self, choice):

--- a/Sublime Text 3 Package/Critic Markup/mark_critic.py
+++ b/Sublime Text 3 Package/Critic Markup/mark_critic.py
@@ -2,7 +2,7 @@ import sublime, sublime_plugin
 
 class MarkCriticCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        self.options = ['Deletion', 'Addition', 'Substitution', 'Comment', "highlight"]
+        self.options = ['Deletion', 'Addition', 'Substitution', 'Comment', "Highlight"]
         # Need to find scope limits then do regex find within current scope
         self.view.window().show_quick_panel(self.options, self.process_critic_mark, sublime.MONOSPACE_FONT)
 
@@ -33,5 +33,5 @@ class MarkCriticCommand(sublime_plugin.TextCommand):
                 # self.view.replace(edit, sel, "{>>"+text+"<<}")
                 edit = self.view.run_command("critic_replace", {"a": sel.a, "b": sel.b, "txt": "{>>" + text + "<<}"})
             if choice == 4:
-                # self.view.replace(edit, sel, "{{"+text+"}}")
-                edit = self.view.run_command("critic_replace", {"a": sel.a, "b": sel.b, "txt": "{{" + text + "}}"})
+                # self.view.replace(edit, sel, "{=="+text+"==}")
+                edit = self.view.run_command("critic_replace", {"a": sel.a, "b": sel.b, "txt": "{==" + text + "==}"})


### PR DESCRIPTION
Hi, I have changed the highlight syntax from {{ }} to {== ==}, also fixed the syntax highlighting.
