### PR TITLE
Make Services accept/reject all in selection.

### DIFF
--- a/Mac System Services/Accept Critic Mark.workflow/Contents/document.wflow
+++ b/Mac System Services/Accept Critic Mark.workflow/Contents/document.wflow
@@ -70,16 +70,10 @@ del_edit = re.compile(r'(?s)\{\-\-(.*?)\-\-[ \t]*(\[(.*?)\])?[ \t]*\}')
 sub_edit = re.compile(r'''(?s)\{\~\~(?P&lt;original&gt;(?:[^\~\&gt;]|(?:\~(?!\&gt;)))+)\~\&gt;(?P&lt;new&gt;(?:[^\~\~]|(?:\~(?!\~\})))+)\~\~\}''')
 
 if len(selected_string) &gt; 0:
-    a = add_edit.search(selected_string)
-    d = del_edit.search(selected_string)
-    s = sub_edit.search(selected_string)
-    if a:
-        print a.group(1)
-    if d:
-		""
-    if s:
-		print s.group('new')
-        
+    a = add_edit.sub(r'\1', selected_string)
+    d = del_edit.sub(r'', a)
+    s = sub_edit.sub(r'\2', d)
+    print s
 else:
 	print selected_string</string>
 					<key>CheckedForUserDefaultShell</key>

--- a/Mac System Services/Reject Critic Mark.workflow/Contents/document.wflow
+++ b/Mac System Services/Reject Critic Mark.workflow/Contents/document.wflow
@@ -70,16 +70,11 @@ del_edit = re.compile(r'(?s)\{\-\-(.*?)\-\-[ \t]*(\[(.*?)\])?[ \t]*\}')
 sub_edit = re.compile(r'''(?s)\{\~\~(?P&lt;original&gt;(?:[^\~\&gt;]|(?:\~(?!\&gt;)))+)\~\&gt;(?P&lt;new&gt;(?:[^\~\~]|(?:\~(?!\~\})))+)\~\~\}''')
 
 if len(selected_string) &gt; 0:
-    a = add_edit.search(selected_string)
-    d = del_edit.search(selected_string)
-    s = sub_edit.search(selected_string)
-    if a:
-        print ""
-    if d:
-        print d.group(1)
-    if s:
-        print s.group('original')
-        
+    a = add_edit.sub(r'', selected_string)
+    d = del_edit.sub(r'\1', a)
+    s = sub_edit.sub(r'\1', d)
+    print s
+
 else:
 	print selected_string</string>
 					<key>CheckedForUserDefaultShell</key>


### PR DESCRIPTION
Replaced the addition, deletion and substitution regular expression
searches with substitutions and I daisy chained the outputs of the 
substitutions. This means that it's not longer necessary to select
_only_ the critic markup section; it's possible to select any text,
as long as it contains the markup to accept/reject.

It's now possible to select a section with multiple edits,
even the whole document and "accept all" or "reject all".
