### PR TITLE
Add two BBEdit text filters that match the functionality of the "accept" & "reject" services.

### DIFF
--- a/BBEdit Additions/Text Filters/00)Accept CMark
+++ b/BBEdit Additions/Text Filters/00)Accept CMark
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# CriticMarkup accept change script for BBEdit
+
+myMark = STDIN.read
+
+# CriticMarks
+# -----------
+# Addition {++ ++}
+# Deletion {-- --}
+# Substitution {~~ ~> ~~}
+# Comment {>> <<}
+# Highlight {== ==}{>> <<}
+
+addition_mark = /^\{\+\+(.+?)\+\+\}$/
+deletion_mark = /^\{\-\-(.+?)\-\-\}$/
+sub_mark = /^\{\~\~(.+?)\~\>(.+?)\~\~\}$/
+comment_mark = /^\{\>\>(.+?)\<\<\}/
+highlight_mark = /^\{\=\=(.+?)\=\=\}\{\>\>(.+?)\<\<\}$/
+
+if addition_mark =~ myMark
+  print myMark.gsub(addition_mark, "\\1").chomp
+  elsif  deletion_mark =~ myMark
+    print ""
+  elsif sub_mark =~ myMark
+    print myMark.gsub(sub_mark, "\\2").chomp
+  else 
+end

--- a/BBEdit Additions/Text Filters/00)Reject CMark
+++ b/BBEdit Additions/Text Filters/00)Reject CMark
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# CriticMarkup reject change script for BBEdit
+
+myMark = STDIN.read
+
+# CriticMarks
+# -----------
+# Addition {++ ++}
+# Deletion {-- --}
+# Substitution {~~ ~> ~~}
+# Comment {>> <<}
+# Highlight {== ==}{>> <<}
+
+addition_mark = /^\{\+\+(.+?)\+\+\}$/
+deletion_mark = /^\{\-\-(.+?)\-\-\}$/
+sub_mark = /^\{\~\~(.+?)\~\>(.+?)\~\~\}$/
+comment_mark = /^\{\>\>(.+?)\<\<\}/
+highlight_mark = /^\{\=\=(.+?)\=\=\}\{\>\>(.+?)\<\<\}$/
+
+if addition_mark =~ myMark
+  print ""
+elsif  deletion_mark =~ myMark
+  print myMark.gsub(deletion_mark, "\\1")
+elsif sub_mark =~ myMark
+  print myMark.gsub(sub_mark, "\\1")
+else 
+  
+end

--- a/BBEdit Additions/Text Filters/README.markdown
+++ b/BBEdit Additions/Text Filters/README.markdown
@@ -1,0 +1,8 @@
+You can put BBEdit text filters in the `Text Filters` folder of your BBEdit configuration folder (`~/Library/Application Support/BBEdit/Text Filters`) unless you've moved your configuration directory to Dropbox).
+
+1. Put them in the appropriate folder
+2. (Re)start BBEdit
+
+You can also assign keyboard shortcuts to each of the filters from BBEdit's preferences (**Menus & Shortcuts** &raquo; **Text** &raquo; **Apply Text Filter**). The "control" combinations are largely unused in BBEdit (with the exception of control-s, which is used for progressive search).
+
+Finally, you can make the filters appear at the top of the Filters menu by prepending `00)` to the filename of each.


### PR DESCRIPTION
The Critic Markup toolkit ships with a pair of services to accept/reject Critic Markup annotations. These text filters largely recreate those services. Adding these to provide an alternative to the services.
