### PR TITLE
Improve usability of CLI processor

### DIFF
--- a/CLI/criticParser_CLI.py
+++ b/CLI/criticParser_CLI.py
@@ -372,7 +372,7 @@ try:
 		filesource.close()
 		print "\nOutput file created:  ", abs_path
 	else:
-		path, filename = os.path.split(args.source)
+		path, filename = os.path.split(os.path.abspath(args.source))
 		print "Converting >> " + args.source
 		output_file = path+'/'+filename.split(os.extsep, 1)[0]+'_CriticParseOut.html'
 		file = open(output_file, 'w')

--- a/CLI/criticParser_CLI.py
+++ b/CLI/criticParser_CLI.py
@@ -349,15 +349,15 @@ try:
 
 
 
-	
+        enc_info = "\n" + '<meta charset="{}">'.format(args.encoding)
 
 	if (args.css):
 		css_file = args.css
 		cssText = css_file.read()
 		css_file.close()
-		h = head + cssText + bodybegin + h + headend
+		h = head + enc_info + cssText + bodybegin + h + headend
 	else:
-	 	h = jq + a + bodybegin + h + headend
+		h = jq + enc_info + a + bodybegin + h + headend
 
 
 

--- a/CLI/criticParser_CLI.py
+++ b/CLI/criticParser_CLI.py
@@ -311,14 +311,14 @@ parser.add_argument('-m2', help='Use the markdown2 python module. If left blank 
 parser.add_argument('-o','--output', help='Path to store the output file, including file name', metavar='out-file', type=argparse.FileType('wt'), required=False)
 parser.add_argument('-css','--css', help='Path to a custom CSS file, including file name', metavar='in-file', type=argparse.FileType('rt'),required=False)
 parser.add_argument('-b', '--browser', help='View the output file in the default browser after saving.', action='store_true')
+parser.add_argument('-e', '--encoding', help='Encoding of input (default: UTF-8)', action='store', default="UTF-8")
+
 
 args = parser.parse_args()
 try:
 	
-
-
 	if args.source:
-		inputFile = codecs.open(args.source, "r", encoding="UTF-8")
+		inputFile = codecs.open(args.source, "r", encoding=args.encoding)
 		inputText = inputFile.read()
 		inputFile.close()
 	else:

--- a/CLI/criticParser_CLI.py
+++ b/CLI/criticParser_CLI.py
@@ -318,7 +318,7 @@ try:
 
 
 	if args.source:
-		inputFile = open(args.source, "r")
+		inputFile = codecs.open(args.source, "r", encoding="UTF-8")
 		inputText = inputFile.read()
 		inputFile.close()
 	else:


### PR DESCRIPTION
- assume UTF-8 for input instead of ASCII
- fix output file name generation
- add `(-e|--encoding)` argument to CLI processor, which should fix #33
